### PR TITLE
Fixed for release MoonShine

### DIFF
--- a/public/js/layouts.js
+++ b/public/js/layouts.js
@@ -37,14 +37,14 @@ document.addEventListener('alpine:init', () => {
                 name: name,
                 counts: layoutsCount
             }, {}, {
-                beforeCallback: function(data) {
+                afterResponse: function(data) {
                     const tempContainer = document.createElement('div');
                     tempContainer.innerHTML = data.html ?? '';
 
                     while (tempContainer.firstChild) {
                         t.blocksContainer.appendChild(tempContainer.firstChild);
                     }
-                    
+
                     t._reindex()
                 }
             })

--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -3,7 +3,7 @@
         {!! $heading !!}
     </x-slot>
 
-    <x-slot name="button"></x-slot>
+    <x-slot name="button">{!! $button !!}</x-slot>
 
     {!! $fields !!}
 </x-moonshine::collapse>

--- a/resources/views/layouts.blade.php
+++ b/resources/views/layouts.blade.php
@@ -14,6 +14,4 @@
     <div>
         {!! $dropdown !!}
     </div>
-
-    <br />
 </div>

--- a/src/Fields/Layout.php
+++ b/src/Fields/Layout.php
@@ -129,8 +129,6 @@ final class Layout implements LayoutContract
                 FlexibleRender::make($this->title()),
 
                 ...$this->getHeadingAdditionalFields(),
-
-                $this->getRemoveButton(),
             ]))
                 ->customAttributes(['class' => 'w-full'])
                 ->itemsAlign('center')
@@ -188,6 +186,7 @@ final class Layout implements LayoutContract
         return view('moonshine-layouts-field::layout', [
             'key' => $this->key(),
             'heading' => FieldsGroup::make($this->headingFields()),
+            'button' => $this->getRemoveButton(),
             'fields' => FieldsGroup::make($this->fields()),
         ]);
     }

--- a/src/Fields/Layouts.php
+++ b/src/Fields/Layouts.php
@@ -8,9 +8,11 @@ use Closure;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Collection;
 use MoonShine\AssetManager\Js;
+use MoonShine\Contracts\Core\HasComponentsContract;
 use MoonShine\Contracts\Core\PageContract;
 use MoonShine\Contracts\Core\ResourceContract;
 use MoonShine\Contracts\UI\ActionButtonContract;
+use MoonShine\Contracts\UI\Collection\ComponentsContract;
 use MoonShine\Contracts\UI\HasFieldsContract;
 use MoonShine\Layouts\Casts\LayoutItem;
 use MoonShine\Layouts\Casts\LayoutsCast;
@@ -169,9 +171,15 @@ final class Layouts extends Field
         return LayoutCollection::make($filled);
     }
 
-    private function fillClonedRecursively(Collection $collection, mixed $data): Collection
+    private function fillClonedRecursively(ComponentsContract|Collection $collection, mixed $data): Collection
     {
         return $collection->map(function (mixed $item) use ($data) {
+            if ($item instanceof HasComponentsContract) {
+                $item = (clone $item)->setComponents(
+                    $this->fillClonedRecursively($item->getComponents(), $data)->toArray()
+                );
+            }
+
             if ($item instanceof HasFieldsContract) {
                 $item = (clone $item)->fields(
                     $this->fillClonedRecursively($item->getFields(), $data)->toArray()


### PR DESCRIPTION
- [Renaming method from beforeCallbask to afterResponse](https://github.com/moonshine-software/layouts-field/commit/61673fa7f7698485704ca9e37ce3fdb8f92277e0)
See MoonShine PR: [#1313](https://github.com/moonshine-software/moonshine/pull/1313)

- [Positioning the remove button](https://github.com/moonshine-software/layouts-field/commit/cb91b6d334d03e79df7b96f86dd8bc6033373921)
before
![before](https://github.com/user-attachments/assets/c1f1dc99-2aad-4fdc-96a1-d4acee30e111)
after
![after](https://github.com/user-attachments/assets/522da03d-99be-4a13-bf64-3d9b48141171)

- [Filled layouts with components](https://github.com/moonshine-software/layouts-field/commit/a09cdf4d4495de1c4929c62be2e764f8d53b47c0)
```php
Layouts::make('Content')
    ->addLayout('Contact information', 'contacts', [
        Grid::make([
            Column::make([
                Text::make('Name'),
            ])
                ->columnSpan(6),
            Column::make([
                Email::make('Email'),
            ])
                ->columnSpan(6),
        ])
    ])
```