### PR TITLE
Route uri keys nowOn fix

### DIFF
--- a/src/Fields/Layouts.php
+++ b/src/Fields/Layouts.php
@@ -109,8 +109,10 @@ final class Layouts extends Field
     public function getAddRoute(): string
     {
         return route('moonshine.layouts-field.store', [
-            'resourceUri' => $this->resource ? $this->resource->getUriKey() : moonshineRequest()->getResourceUri(),
-            'pageUri' => $this->page ? $this->page->getUriKey() : moonshineRequest()->getPageUri(),
+            'resourceUri' => $this->getNowOnResource() ? $this->getNowOnResource()->getUriKey() :
+                ($this->resource ? $this->resource->getUriKey() : moonshineRequest()->getResourceUri()),
+            'pageUri' => $this->getNowOnPage() ? $this->getNowOnPage()->getUriKey() :
+                ($this->page ? $this->page->getUriKey() : moonshineRequest()->getPageUri()),
         ]);
     }
 


### PR DESCRIPTION
Куда-то потерялась возможность в 3 версии назначать кастомные ресурсы и страницу при работе Layouts в окошке через HasMany.
Так работает, однако возможно есть путь легче. Но других вариантов, прошерстив доку и пакет, не нашёл.