### PR TITLE
feat: Поддержка вложенных Layouts

### DIFF
--- a/public/js/layouts.js
+++ b/public/js/layouts.js
@@ -4,12 +4,10 @@ document.addEventListener('alpine:init', () => {
         column: column,
         root: null,
         blocksContainer: null,
-
         init() {
             this.root = this.$root
             this.blocksContainer = this.root.querySelector('._layouts-blocks')
             this._reindex()
-
             const t = this
 
             MoonShine.iterable.sortable(
@@ -17,68 +15,61 @@ document.addEventListener('alpine:init', () => {
                 null,
                 'layouts',
                 null,
-                { handle: '.handle' },
-                function() { t._reindex() },
+                {
+                    handle: '.handle'
+                },
+                function(evt) {
+                    t._reindex()
+                }
             )
         },
-
         add(name) {
             const t = this
 
-            let counts = {}
-            document.querySelectorAll('._layout-value').forEach(function(l) {
-                counts[l.value] = (counts[l.value] || 0) + 1
+            let layoutsCount = {}
+            const layouts = document.querySelectorAll('._layout-value')
+            layouts.forEach(function(l) {
+                layoutsCount[l.value] = layoutsCount[l.value] ? layoutsCount[l.value]+1 : 1
             })
+
 
             MoonShine.request(t, t.url, 'post', {
                 field: t.column,
                 name: name,
-                counts: counts,
+                counts: layoutsCount
             }, {}, {
                 afterResponse: function(data) {
-                    const temp = document.createElement('div')
-                    temp.innerHTML = data.html ?? data.htmlData[0].html ?? ''
+                    const tempContainer = document.createElement('div');
+                    tempContainer.innerHTML = data.html ?? data.htmlData[0].html ?? '';
 
-                    while (temp.firstChild) {
-                        t.blocksContainer.appendChild(temp.firstChild)
+                    while (tempContainer.firstChild) {
+                        t.blocksContainer.appendChild(tempContainer.firstChild);
                     }
 
                     t._reindex()
 
-                    t.$nextTick(function() {
-                        document.dispatchEvent(
-                            new CustomEvent('layouts:block-added', {
-                                bubbles: true,
-                                detail: { name: name, column: t.column },
-                            }),
-                        )
-                    })
-                },
+					t.$nextTick(function () {
+                            document.dispatchEvent(
+                                new CustomEvent('layouts:block-added', {
+                                    bubbles: true,
+                                    detail: { name: name, column: t.column },
+                                }),
+                            );
+					})
+                }
             })
         },
-
         remove() {
             this.$el.closest('._layouts-block').remove()
             this._reindex()
         },
-
-        /**
-         * Orchestrates reindexing in two phases:
-         *
-         * 1. MoonShine iterable.reindex — handles level-0 field names
-         *    and position displays. Async (uses await $nextTick internally).
-         *
-         * 2. _reindexFields (deferred via setTimeout 0) — runs after
-         *    iterable.reindex fully completes, computing correct indices
-         *    for ALL nesting levels from DOM positions.
-         */
         _reindex() {
             const t = this
 
             this.$nextTick(function() {
                 MoonShine.iterable.reindex(
                     t.blocksContainer,
-                    '._layouts-block',
+                    '._layouts-block'
                 )
 
                 setTimeout(function() {
@@ -86,14 +77,6 @@ document.addEventListener('alpine:init', () => {
                 }, 0)
             })
         },
-
-        /**
-         * Recomputes and applies block indices to position displays
-         * and field name attributes across all nesting levels.
-         *
-         * Reads indices from DOM position (not data-r-index) so it's
-         * independent of iterable.reindex timing.
-         */
         _reindexFields() {
             const t = this
 
@@ -104,7 +87,7 @@ document.addEventListener('alpine:init', () => {
                 let count = 0
                 for (let i = 0; i < parent.children.length; i++) {
                     if (parent.children[i] === block) return count
-                    if (parent.children[i].classList?.contains('_layouts-block')) {
+                    if (parent.children[i].classList && parent.children[i].classList.contains('_layouts-block')) {
                         count++
                     }
                 }
@@ -113,7 +96,7 @@ document.addEventListener('alpine:init', () => {
 
             function findPositionDisplay(block) {
                 return block.querySelector(
-                    ':scope > .accordion-item > .accordion-btn [data-increment-position]',
+                    ':scope > .accordion-item > .accordion-btn [data-increment-position]'
                 )
             }
 
@@ -158,12 +141,12 @@ document.addEventListener('alpine:init', () => {
                     if (isNaN(level) || level < 1) return
 
                     const dataName = el.getAttribute('data-name')
-                    if (dataName && dataName.includes('${index')) {
+                    if (dataName && dataName.indexOf('${index') !== -1) {
                         el.setAttribute('name', resolveName(dataName, indices))
                     }
 
                     const validationField = el.getAttribute('data-validation-field')
-                    if (validationField && validationField.includes('${index')) {
+                    if (validationField && validationField.indexOf('${index') !== -1) {
                         el.setAttribute('data-validation-field', resolveName(validationField, indices))
                     }
                 })
@@ -180,12 +163,13 @@ document.addEventListener('alpine:init', () => {
                 const container = layoutRoot.querySelector(':scope > ._layouts-blocks')
                 if (!container) return
 
-                Array.from(container.children).forEach(function(block) {
-                    if (block.classList?.contains('_layouts-block')) {
+                for (let i = 0; i < container.children.length; i++) {
+                    const block = container.children[i]
+                    if (block.classList && block.classList.contains('_layouts-block')) {
                         applyIndices(block)
                     }
-                })
+                }
             })
-        },
+        }
     }))
 })

--- a/public/js/layouts.js
+++ b/public/js/layouts.js
@@ -1,3 +1,77 @@
+function countBlocksBefore(block) {
+    const parent = block.parentElement
+    if (!parent) return 0
+
+    let count = 0
+    for (let i = 0; i < parent.children.length; i++) {
+        if (parent.children[i] === block) return count
+        if (parent.children[i].classList && parent.children[i].classList.contains('_layouts-block')) {
+            count++
+        }
+    }
+    return count
+}
+
+function findPositionDisplay(block) {
+    return block.querySelector(
+        ':scope > .accordion-item > .accordion-btn [data-increment-position]'
+    )
+}
+
+function resolveIndexChain(startBlock) {
+    const indices = []
+    let searchFrom = startBlock
+
+    while (searchFrom) {
+        const block = searchFrom.closest('._layouts-block')
+        if (!block) break
+
+        indices.unshift(countBlocksBefore(block) + 1)
+
+        const layoutsRoot = block.closest('[data-top-level]')
+        if (!layoutsRoot) break
+        searchFrom = layoutsRoot.parentElement
+    }
+
+    return indices
+}
+
+function resolveName(template, indices) {
+    let result = template
+    for (let i = 0; i < indices.length; i++) {
+        result = result.split('${index' + i + '}').join(indices[i])
+    }
+    return result
+}
+
+function applyIndices(block, layoutRoot) {
+    const indices = resolveIndexChain(block)
+
+    const positionEl = findPositionDisplay(block)
+    if (positionEl) {
+        const position = indices[indices.length - 1]
+        positionEl.setAttribute('data-r-index', position)
+        positionEl.innerHTML = position
+    }
+
+    block.querySelectorAll('[data-level]').forEach(function(el) {
+        if (el.closest('[data-top-level]') !== layoutRoot) return
+
+        const level = parseInt(el.getAttribute('data-level'))
+        if (isNaN(level) || level < 1) return
+
+        const dataName = el.getAttribute('data-name')
+        if (dataName && dataName.indexOf('${index') !== -1) {
+            el.setAttribute('name', resolveName(dataName, indices))
+        }
+
+        const validationField = el.getAttribute('data-validation-field')
+        if (validationField && validationField.indexOf('${index') !== -1) {
+            el.setAttribute('data-validation-field', resolveName(validationField, indices))
+        }
+    })
+}
+
 document.addEventListener('alpine:init', () => {
     Alpine.data('layouts', (url, column) => ({
         url: url,
@@ -81,80 +155,6 @@ document.addEventListener('alpine:init', () => {
         },
         _reindexFields() {
             const t = this
-
-            function countBlocksBefore(block) {
-                const parent = block.parentElement
-                if (!parent) return 0
-
-                let count = 0
-                for (let i = 0; i < parent.children.length; i++) {
-                    if (parent.children[i] === block) return count
-                    if (parent.children[i].classList && parent.children[i].classList.contains('_layouts-block')) {
-                        count++
-                    }
-                }
-                return count
-            }
-
-            function findPositionDisplay(block) {
-                return block.querySelector(
-                    ':scope > .accordion-item > .accordion-btn [data-increment-position]'
-                )
-            }
-
-            function resolveIndexChain(startBlock) {
-                const indices = []
-                let searchFrom = startBlock
-
-                while (searchFrom) {
-                    const block = searchFrom.closest('._layouts-block')
-                    if (!block) break
-
-                    indices.unshift(countBlocksBefore(block) + 1)
-
-                    const layoutsRoot = block.closest('[data-top-level]')
-                    if (!layoutsRoot) break
-                    searchFrom = layoutsRoot.parentElement
-                }
-
-                return indices
-            }
-
-            function resolveName(template, indices) {
-                let result = template
-                for (let i = 0; i < indices.length; i++) {
-                    result = result.split('${index' + i + '}').join(indices[i])
-                }
-                return result
-            }
-
-            function applyIndices(block, layoutRoot) {
-                const indices = resolveIndexChain(block)
-
-                const positionEl = findPositionDisplay(block)
-                if (positionEl) {
-                    const position = indices[indices.length - 1]
-                    positionEl.setAttribute('data-r-index', position)
-                    positionEl.innerHTML = position
-                }
-
-                block.querySelectorAll('[data-level]').forEach(function(el) {
-                    if (el.closest('[data-top-level]') !== layoutRoot) return
-
-                    const level = parseInt(el.getAttribute('data-level'))
-                    if (isNaN(level) || level < 1) return
-
-                    const dataName = el.getAttribute('data-name')
-                    if (dataName && dataName.indexOf('${index') !== -1) {
-                        el.setAttribute('name', resolveName(dataName, indices))
-                    }
-
-                    const validationField = el.getAttribute('data-validation-field')
-                    if (validationField && validationField.indexOf('${index') !== -1) {
-                        el.setAttribute('data-validation-field', resolveName(validationField, indices))
-                    }
-                })
-            }
 
             const layoutRoots = [t.root]
             t.root.querySelectorAll('[data-top-level]').forEach(function(el) {

--- a/public/js/layouts.js
+++ b/public/js/layouts.js
@@ -63,6 +63,7 @@ document.addEventListener('alpine:init', () => {
             this.$el.closest('._layouts-block').remove()
             this._reindex()
         },
+        _reindexTimer: null,
         _reindex() {
             const t = this
 
@@ -72,7 +73,8 @@ document.addEventListener('alpine:init', () => {
                     '._layouts-block'
                 )
 
-                setTimeout(function() {
+                clearTimeout(t._reindexTimer)
+                t._reindexTimer = setTimeout(function() {
                     t._reindexFields()
                 }, 0)
             })
@@ -126,7 +128,7 @@ document.addEventListener('alpine:init', () => {
                 return result
             }
 
-            function applyIndices(block) {
+            function applyIndices(block, layoutRoot) {
                 const indices = resolveIndexChain(block)
 
                 const positionEl = findPositionDisplay(block)
@@ -137,6 +139,8 @@ document.addEventListener('alpine:init', () => {
                 }
 
                 block.querySelectorAll('[data-level]').forEach(function(el) {
+                    if (el.closest('[data-top-level]') !== layoutRoot) return
+
                     const level = parseInt(el.getAttribute('data-level'))
                     if (isNaN(level) || level < 1) return
 
@@ -166,7 +170,7 @@ document.addEventListener('alpine:init', () => {
                 for (let i = 0; i < container.children.length; i++) {
                     const block = container.children[i]
                     if (block.classList && block.classList.contains('_layouts-block')) {
-                        applyIndices(block)
+                        applyIndices(block, layoutRoot)
                     }
                 }
             })

--- a/public/js/layouts.js
+++ b/public/js/layouts.js
@@ -4,10 +4,12 @@ document.addEventListener('alpine:init', () => {
         column: column,
         root: null,
         blocksContainer: null,
+
         init() {
             this.root = this.$root
             this.blocksContainer = this.root.querySelector('._layouts-blocks')
             this._reindex()
+
             const t = this
 
             MoonShine.iterable.sortable(
@@ -15,63 +17,175 @@ document.addEventListener('alpine:init', () => {
                 null,
                 'layouts',
                 null,
-                {
-                    handle: '.handle'
-                },
-                function(evt) {
-                    t._reindex()
-                }
+                { handle: '.handle' },
+                function() { t._reindex() },
             )
         },
+
         add(name) {
             const t = this
 
-            let layoutsCount = {}
-            const layouts = document.querySelectorAll('._layout-value')
-            layouts.forEach(function(l) {
-                layoutsCount[l.value] = layoutsCount[l.value] ? layoutsCount[l.value]+1 : 1
+            let counts = {}
+            document.querySelectorAll('._layout-value').forEach(function(l) {
+                counts[l.value] = (counts[l.value] || 0) + 1
             })
-
 
             MoonShine.request(t, t.url, 'post', {
                 field: t.column,
                 name: name,
-                counts: layoutsCount
+                counts: counts,
             }, {}, {
                 afterResponse: function(data) {
-                    const tempContainer = document.createElement('div');
-                    tempContainer.innerHTML = data.html ?? data.htmlData[0].html ?? '';
+                    const temp = document.createElement('div')
+                    temp.innerHTML = data.html ?? data.htmlData[0].html ?? ''
 
-                    while (tempContainer.firstChild) {
-                        t.blocksContainer.appendChild(tempContainer.firstChild);
+                    while (temp.firstChild) {
+                        t.blocksContainer.appendChild(temp.firstChild)
                     }
 
                     t._reindex()
 
-					t.$nextTick(function () {
-                            document.dispatchEvent(
-                                new CustomEvent('layouts:block-added', {
-                                    bubbles: true,
-                                    detail: { name: name, column: t.column },
-                                }),
-                            );
-					})
-                }
+                    t.$nextTick(function() {
+                        document.dispatchEvent(
+                            new CustomEvent('layouts:block-added', {
+                                bubbles: true,
+                                detail: { name: name, column: t.column },
+                            }),
+                        )
+                    })
+                },
             })
         },
+
         remove() {
             this.$el.closest('._layouts-block').remove()
             this._reindex()
         },
+
+        /**
+         * Orchestrates reindexing in two phases:
+         *
+         * 1. MoonShine iterable.reindex — handles level-0 field names
+         *    and position displays. Async (uses await $nextTick internally).
+         *
+         * 2. _reindexFields (deferred via setTimeout 0) — runs after
+         *    iterable.reindex fully completes, computing correct indices
+         *    for ALL nesting levels from DOM positions.
+         */
         _reindex() {
             const t = this
 
             this.$nextTick(function() {
                 MoonShine.iterable.reindex(
                     t.blocksContainer,
-                    '._layouts-block'
+                    '._layouts-block',
                 )
+
+                setTimeout(function() {
+                    t._reindexFields()
+                }, 0)
             })
-        }
+        },
+
+        /**
+         * Recomputes and applies block indices to position displays
+         * and field name attributes across all nesting levels.
+         *
+         * Reads indices from DOM position (not data-r-index) so it's
+         * independent of iterable.reindex timing.
+         */
+        _reindexFields() {
+            const t = this
+
+            function countBlocksBefore(block) {
+                const parent = block.parentElement
+                if (!parent) return 0
+
+                let count = 0
+                for (let i = 0; i < parent.children.length; i++) {
+                    if (parent.children[i] === block) return count
+                    if (parent.children[i].classList?.contains('_layouts-block')) {
+                        count++
+                    }
+                }
+                return count
+            }
+
+            function findPositionDisplay(block) {
+                return block.querySelector(
+                    ':scope > .accordion-item > .accordion-btn [data-increment-position]',
+                )
+            }
+
+            function resolveIndexChain(startBlock) {
+                const indices = []
+                let searchFrom = startBlock
+
+                while (searchFrom) {
+                    const block = searchFrom.closest('._layouts-block')
+                    if (!block) break
+
+                    indices.unshift(countBlocksBefore(block) + 1)
+
+                    const layoutsRoot = block.closest('[data-top-level]')
+                    if (!layoutsRoot) break
+                    searchFrom = layoutsRoot.parentElement
+                }
+
+                return indices
+            }
+
+            function resolveName(template, indices) {
+                let result = template
+                for (let i = 0; i < indices.length; i++) {
+                    result = result.split('${index' + i + '}').join(indices[i])
+                }
+                return result
+            }
+
+            function applyIndices(block) {
+                const indices = resolveIndexChain(block)
+
+                const positionEl = findPositionDisplay(block)
+                if (positionEl) {
+                    const position = indices[indices.length - 1]
+                    positionEl.setAttribute('data-r-index', position)
+                    positionEl.innerHTML = position
+                }
+
+                block.querySelectorAll('[data-level]').forEach(function(el) {
+                    const level = parseInt(el.getAttribute('data-level'))
+                    if (isNaN(level) || level < 1) return
+
+                    const dataName = el.getAttribute('data-name')
+                    if (dataName && dataName.includes('${index')) {
+                        el.setAttribute('name', resolveName(dataName, indices))
+                    }
+
+                    const validationField = el.getAttribute('data-validation-field')
+                    if (validationField && validationField.includes('${index')) {
+                        el.setAttribute('data-validation-field', resolveName(validationField, indices))
+                    }
+                })
+            }
+
+            const layoutRoots = [t.root]
+            t.root.querySelectorAll('[data-top-level]').forEach(function(el) {
+                if (el !== t.root) {
+                    layoutRoots.push(el)
+                }
+            })
+
+            layoutRoots.forEach(function(layoutRoot) {
+                const container = layoutRoot.querySelector(':scope > ._layouts-blocks')
+                if (!container) return
+
+                Array.from(container.children).forEach(function(block) {
+                    if (block.classList?.contains('_layouts-block')) {
+                        applyIndices(block)
+                    }
+                })
+            })
+        },
     }))
 })

--- a/resources/views/layouts.blade.php
+++ b/resources/views/layouts.blade.php
@@ -4,6 +4,7 @@
 )"
     {{ $attributes->class('space-y-2') }}
     data-top-level="true"
+    data-r-item-selector=":scope > ._layouts-blocks > ._layouts-block"
 >
     <div class="_layouts-blocks space-y-2">
         @foreach($fields as $layout)

--- a/src/Http/Controllers/LayoutsController.php
+++ b/src/Http/Controllers/LayoutsController.php
@@ -78,8 +78,61 @@ final class LayoutsController extends MoonShineController
             };
         }
 
-        return $fields
-            ->onlyFields()
-            ->findByColumn($request->get('field'));
+        $column = $request->get('field');
+
+        // Original top-level search (for non-nested Layouts)
+        $field = $fields->onlyFields()->findByColumn($column);
+
+        if ($field instanceof Layouts) {
+            return $field;
+        }
+
+        // Fallback: recursive search inside nested Layouts fields
+        return $this->findNestedLayouts($fields->onlyFields(), $column);
+    }
+
+    /**
+     * Recursively search for a Layouts field by column inside other Layouts fields.
+     *
+     * @param  iterable  $fields  Flattened fields collection (onlyFields result)
+     * @param  string  $column  The column to find
+     */
+    private function findNestedLayouts(iterable $fields, string $column): ?Layouts
+    {
+        foreach ($fields as $field) {
+            if (! $field instanceof Layouts) {
+                continue;
+            }
+
+            // Direct match
+            if ($field->getColumn() === $column) {
+                return $field;
+            }
+
+            // Recurse into this Layouts field's Layout objects
+            foreach ($field->getLayouts() as $layout) {
+                $nested = $this->findNestedLayouts($layout->fields()->onlyFields(), $column);
+
+                if ($nested !== null) {
+                    // Set the parent prefix on the found field so that
+                    // prepareReindexNames generates correct field names
+                    // e.g. blocks[${index0}][content] instead of just content
+                    $parentNameDot = $field->getNameDot();
+                    $level = substr_count($parentNameDot, '$');
+
+                    $nested->setNameAttribute(
+                        $nested->generateNameFrom(
+                            $parentNameDot,
+                            "\${index$level}",
+                            $nested->getColumn(),
+                        )
+                    );
+
+                    return $nested;
+                }
+            }
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
Поле Layouts теперь можно вкладывать внутрь блока другого Layouts на любую глубину. Позиции блоков и имена полей корректно рассчитываются на всех уровнях вложенности при добавлении, удалении и сортировке.

## Что изменилось

### `LayoutsController.php`
Добавлен `findNestedLayouts()` — рекурсивный поиск поля по column внутри других Layouts. При нахождении выставляет родительский prefix в имя поля, чтобы сервер возвращал корректный HTML для AJAX-добавления блока на любом уровне.

### `layouts.blade.php`
Добавлен `data-r-item-selector` — scoped-селектор ограничивает `iterable.reindex` только прямыми потомками, чтобы он не пытался переиндексировать чужую вложенность.

### `layouts.js`
Добавлены `_reindexFields()`:

- `_reindex()` — вызывает штатный `iterable.reindex` для level-0 полей, затем через `setTimeout(0)` запускает `_reindexFields()` (после того, как все асинхронные microtasks MoonShine завершатся). Debounce схлопывает серию быстрых вызовов в один.
- `_reindexFields()` — обходит DOM, считает позицию каждого блока среди соседей, поднимается вверх по дереву и собирает цепочку индексов `[1, 2, ...]`. Проставляет позиции в UI и разрешает плейсхолдеры `${index0}`, `${index1}` в `name` и `data-validation-field`.
- `applyIndices(block, layoutRoot)` — каждый блок обрабатывается только своим `[data-top-level]`, без двойной обработки родителем.